### PR TITLE
Fix managed url with basepath

### DIFF
--- a/api-gateway-config/scripts/lua/lib/utils.lua
+++ b/api-gateway-config/scripts/lua/lib/utils.lua
@@ -77,7 +77,7 @@ end
 --- Generate random uuid
 function uuid()
   local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
-  math.randomseed(os.time())
+  math.randomseed(os.clock())
   return string.gsub(template, '[xy]', function (c)
     local v = (c == 'x') and math.random(0, 0xf) or math.random(8, 0xb)
     return string.format('%x', v)

--- a/api-gateway-config/scripts/lua/management.lua
+++ b/api-gateway-config/scripts/lua/management.lua
@@ -93,13 +93,17 @@ function _M.addAPI()
   end
   -- Return managedUrl object
   local uuid = existingAPI ~= nil and existingAPI.id or utils.uuid()
+  local managedUrl = utils.concatStrings({"http://0.0.0.0:8080/api/", decoded.tenantId})
+  if basePath:sub(1,1) ~= '' then
+    managedUrl = utils.concatStrings({managedUrl, "/", basePath})
+  end
   local managedUrlObj = {
     id = uuid,
     name = decoded.name,
     basePath = utils.concatStrings({"/", basePath}),
     tenantId = decoded.tenantId,
     resources = decoded.resources,
-    managedUrl = utils.concatStrings({"http://0.0.0.0:8080/api/", decoded.tenantId, "/", basePath})
+    managedUrl = managedUrl
   }
   managedUrlObj = cjson.encode(managedUrlObj):gsub("\\", "")
   -- Add API object to redis


### PR DESCRIPTION
* Fixed bug where managedUrl was returning an extra slash at the end when the basepath is set to `/`
* modified uuid randomseed to use `os.clock` which uses milliseconds, rather than `os.time` which uses seconds.
@mhamann @lostinthestory PTAL