### PR TITLE
Redis sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,9 @@ FROM alpine:latest
 
 # install dependencies
 RUN apk update \
-    && apk add gcc tar libtool zlib jemalloc jemalloc-dev perl \ 
+    && apk add gcc tar libtool zlib jemalloc jemalloc-dev perl \
     make musl-dev openssl-dev pcre-dev g++ zlib-dev curl python \
-    perl-test-longstring perl-list-moreutils perl-http-message \
-    geoip-dev nodejs
+    perl-test-longstring perl-list-moreutils perl-http-message geoip-dev
 
 # openresty build
 ENV OPENRESTY_VERSION=1.9.7.3 \

--- a/api-gateway-config/conf.d/management_apis.conf
+++ b/api-gateway-config/conf.d/management_apis.conf
@@ -83,21 +83,31 @@ server {
                  ngx.status = 400
                  ngx.say("Invalid verb")
              end
-
          }
-     }
+    }
 
-    location /subscribe {
+    location /v1/sync {
         access_by_lua_block {
             local mgmt = require("management")
-            mgmt.subscribe()
+            local requestMethod = ngx.req.get_method()
+            if requestMethod == "GET" then
+                mgmt.sync()
+            else
+                ngx.say("Invalid verb")
+            end
         }
     }
 
-    location /unsubscribe {
+    location /v1/subscribe {
         access_by_lua_block {
             local mgmt = require("management")
-            mgmt.unsubscribe()
+            local requestMethod = ngx.req.get_method()
+            if requestMethod == "GET" then
+                mgmt.subscribe()
+            else
+                ngx.say("Invalid verb")
+            end
         }
     }
+
 }

--- a/api-gateway-config/scripts/lua/lib/filemgmt.lua
+++ b/api-gateway-config/scripts/lua/lib/filemgmt.lua
@@ -73,8 +73,6 @@ function _M.createResourceConf(baseConfDir, tenant, gatewayPath, resourceObj)
   })
   file:write(location)
   file:close()
-  -- reload nginx to refresh conf files
-  os.execute("/usr/local/sbin/nginx -s reload")
   return fileLocation
 end
 
@@ -86,8 +84,6 @@ end
 function _M.deleteResourceConf(baseConfDir, tenant, gatewayPath)
   local fileLocation = utils.concatStrings({baseConfDir, tenant, "/", gatewayPath, ".conf"})
   os.execute(utils.concatStrings({"rm -f ", fileLocation}))
-  -- reload nginx to refresh conf files
-  os.execute("/usr/local/sbin/nginx -s reload")
   return fileLocation
 end
 

--- a/api-gateway-config/scripts/lua/lib/logger.lua
+++ b/api-gateway-config/scripts/lua/lib/logger.lua
@@ -21,6 +21,7 @@
 --- @module logger
 -- Module to handle logging in a single place
 -- @author Cody Walker (cmwalker), Alex Song (songs)
+local utils = require "lib/utils"
 
 local _M = {}
 
@@ -33,6 +34,13 @@ end
 --- Handle debug stream to stdout
 -- @param s String to write to debug stream
 function _M.debug(s)
+  if s == nil then
+    s = "nil"
+  elseif type(s) == "table" then
+    s = utils.serializeTable(s)
+  elseif type(s) == "boolean" then
+    s = (s == true) and "true" or "false"
+  end
   os.execute("echo \"" .. s .. "\"")
 end
 

--- a/api-gateway-config/scripts/lua/lib/request.lua
+++ b/api-gateway-config/scripts/lua/lib/request.lua
@@ -31,7 +31,7 @@ local _Request = {}
 -- @param msg error message
 function err(code, msg)
   ngx.status = code
-  ngx.print(utils.concatStrings({"Error: ", msg}))
+  ngx.say(utils.concatStrings({"Error: ", msg}))
   ngx.exit(ngx.status)
 end
 
@@ -40,7 +40,7 @@ end
 -- @param obj object to return
 function success(code, obj)
   ngx.status = code
-  ngx.print(obj)
+  ngx.say(obj)
   ngx.exit(ngx.status)
 end
 

--- a/api-gateway-config/scripts/lua/management.lua
+++ b/api-gateway-config/scripts/lua/management.lua
@@ -24,7 +24,6 @@
 
 local cjson = require "cjson"
 local redis = require "lib/redis"
-local filemgmt = require "lib/filemgmt"
 local utils = require "lib/utils"
 local logger = require "lib/logger"
 local request = require "lib/request"
@@ -56,22 +55,9 @@ local _M = {}
 function _M.addAPI()
   -- Open connection to redis or use one from connection pool
   local red = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 1000)
-  -- Check for api id and use existingAPI if it already exists in redis
+  -- Check for api id from uri and use existingAPI if it already exists in redis
   local uri = string.gsub(ngx.var.request_uri, "?.*", "")
-  local apiId, existingAPI
-  local index = 1
-  for word in string.gmatch(uri, '([^/]+)') do
-    if index == 3 then
-      apiId = word
-    end
-    index = index + 1
-  end
-  if apiId ~= nil then
-    existingAPI = redis.getAPI(red, apiId)
-    if existingAPI == nil then
-      request.err(404, utils.concatStrings({"Unknown API id ", apiId}))
-    end
-  end
+  local existingAPI = checkURIForExisting(red, uri, "api")
   -- Read in the PUT JSON Body
   ngx.req.read_body()
   local args = ngx.req.get_body_data()
@@ -80,6 +66,13 @@ function _M.addAPI()
   end
   -- Convert json into Lua table
   local decoded = cjson.decode(args)
+  -- Check for api id in JSON body
+  if existingAPI == nil and decoded.id ~= nil then
+    existingAPI = redis.getAPI(red, decoded.id)
+    if existingAPI == nil then
+      request.err(404, utils.concatStrings({"Unknown API id ", decoded.id}))
+    end
+  end
   -- Error checking
   local fields = {"name", "basePath", "tenantId", "resources"}
   for k, v in pairs(fields) do
@@ -90,12 +83,7 @@ function _M.addAPI()
   end
   -- Format basePath
   local basePath = decoded.basePath:sub(1,1) == '/' and decoded.basePath:sub(2) or decoded.basePath
-  -- Add resources to redis and create nginx conf files
-  for path, resource in pairs(decoded.resources) do
-    local gatewayPath = utils.concatStrings({basePath, ngx.escape_uri(path)})
-    addResource(red, resource, gatewayPath, decoded.tenantId)
-  end
-  -- Return managedUrl object
+  -- Create managedUrl object
   local uuid = existingAPI ~= nil and existingAPI.id or utils.uuid()
   local managedUrl = utils.concatStrings({"http://", MANAGEDURL_HOST, ":", MANAGEDURL_PORT, "/api/", decoded.tenantId})
   if basePath:sub(1,1) ~= '' then
@@ -109,9 +97,13 @@ function _M.addAPI()
     resources = decoded.resources,
     managedUrl = managedUrl
   }
-  managedUrlObj = cjson.encode(managedUrlObj):gsub("\\", "")
   -- Add API object to redis
-  redis.addAPI(red, uuid, managedUrlObj)
+  managedUrlObj = redis.addAPI(red, uuid, managedUrlObj, existingAPI)
+  -- Add resources to redis
+  for path, resource in pairs(decoded.resources) do
+    local gatewayPath = utils.concatStrings({basePath, ngx.escape_uri(path)})
+    addResource(red, resource, gatewayPath, decoded.tenantId)
+  end
   redis.close(red)
   -- Return managed url object
   ngx.header.content_type = "application/json; charset=utf-8"
@@ -206,7 +198,6 @@ function addResource(red, resource, gatewayPath, tenantId)
   end
   local resourceObj = redis.generateResourceObj(operations, apiId)
   redis.createResource(red, redisKey, REDIS_FIELD, resourceObj)
-  filemgmt.createResourceConf(BASE_CONF_DIR, tenantId, gatewayPath, resourceObj)
 end
 
 --- Get one or all APIs from the gateway
@@ -306,13 +297,14 @@ function _M.deleteAPI()
   if api == nil then
     request.err(404, utils.concatStrings({"Unknown API id ", id}))
   end
+  -- Delete API
+  redis.deleteAPI(red, id)
   -- Delete all resources for the API
   local basePath = api.basePath:sub(2)
   for path, v in pairs(api.resources) do
     local gatewayPath = utils.concatStrings({basePath, ngx.escape_uri(path)})
     deleteResource(red, gatewayPath, api.tenantId)
   end
-  redis.deleteAPI(red, id)
   redis.close(red)
   request.success(200, {})
 end
@@ -324,7 +316,6 @@ end
 function deleteResource(red, gatewayPath, tenantId)
   local redisKey = utils.concatStrings({"resources:", tenantId, ":", ngx.unescape_uri(gatewayPath)})
   redis.deleteResource(red, redisKey, REDIS_FIELD)
-  filemgmt.deleteResourceConf(BASE_CONF_DIR, tenantId, gatewayPath)
 end
 
 -----------------------------
@@ -343,20 +334,7 @@ function _M.addTenant()
   local red = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 1000)
   -- Check for tenant id and use existingTenant if it already exists in redis
   local uri = string.gsub(ngx.var.request_uri, "?.*", "")
-  local tenantId, existingTenant
-  local index = 1
-  for word in string.gmatch(uri, '([^/]+)') do
-    if index == 3 then
-      tenantId = word
-    end
-    index = index + 1
-  end
-  if tenantId ~= nil then
-    existingTenant = redis.getTenant(red, tenantId)
-    if existingTenant == nil then
-      request.err(400, utils.concatStrings({"Unknown tenant id ", tenantId}))
-    end
-  end
+  local existingTenant = checkURIForExisting(red, uri, "tenant")
   -- Read in the PUT JSON Body
   ngx.req.read_body()
   local args = ngx.req.get_body_data()
@@ -365,6 +343,13 @@ function _M.addTenant()
   end
   -- Convert json into Lua table
   local decoded = cjson.decode(args)
+  -- Check for tenant id in JSON body
+  if existingTenant == nil and decoded.id ~= nil then
+    existingTenant = redis.getTenant(red, decoded.id)
+    if existingTenant == nil then
+      request.err(404, utils.concatStrings({"Unknown Tenant id ", decoded.id}))
+    end
+  end
   -- Error checking
   local fields = {"namespace", "instance"}
   for k, v in pairs(fields) do
@@ -379,8 +364,7 @@ function _M.addTenant()
     namespace = decoded.namespace,
     instance = decoded.instance
   }
-  tenantObj = cjson.encode(tenantObj)
-  redis.addTenant(red, uuid, tenantObj)
+  tenantObj = redis.addTenant(red, uuid, tenantObj)
   redis.close(red)
   ngx.header.content_type = "application/json; charset=utf-8"
   request.success(200, tenantObj)
@@ -490,24 +474,22 @@ end
 ----- Pub/Sub with Redis -----
 ------------------------------
 
---- Subscribe to redis
--- GET /subscribe
-function _M.subscribe()
-  -- Initialize and connect to redis
-  local redisGetClient = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 1000)
-  local redisSubClient = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 60000) -- read_reply will timeout every minute
-  logger.debug(utils.concatStrings({"\nConnected to redis at ", REDIS_HOST, ":", REDIS_PORT}))
-  redis.subscribe(redisSubClient, redisGetClient)
+--- Sync with redis
+-- GET /v1/sync
+function _M.sync()
+  local red = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 10000)
+  logger.debug(utils.concatStrings({"Connected to redis at ", REDIS_HOST, ":", REDIS_PORT}))
+  redis.syncWithRedis(red)
   ngx.exit(200)
 end
 
---- Unsusbscribe to redis
--- GET /unsubscribe
-function _M.unsubscribe()
-  -- Initialize and connect to redis
-  local red = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 1000)
-  redis.unsubscribe(red)
-  request.success(200, "Unsubscribed to redis")
+--- Subscribe to redis
+-- GET /v1/subscribe
+function _M.subscribe()
+  local redisGetClient = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 1000)
+  local redisSubClient = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 1000)
+  redis.subscribe(redisSubClient, redisGetClient)
+  ngx.exit(200)
 end
 
 ---------------------------
@@ -604,6 +586,38 @@ function validateSubscriptionBody()
   end
   redisKey = utils.concatStrings({redisKey, ":key:", decoded.key})
   return redisKey
+end
+
+
+--- Check for api id from uri and use existingAPI if it already exists in redis
+-- @param red Redis client instance
+-- @param uri Uri of request. Eg. /v1/apis/{id}
+-- @param type type to look for in redis. "api" or "tenant"
+function checkURIForExisting(red, uri, type)
+  local id, existing
+  local index = 1
+  -- Check if id is in the uri
+  for word in string.gmatch(uri, '([^/]+)') do
+    if index == 3 then
+      id = word
+    end
+    index = index + 1
+  end
+  -- Get object from redis
+  if id ~= nil then
+    if type == "api" then
+      existing = redis.getAPI(red, id)
+      if existing == nil then
+        request.err(404, utils.concatStrings({"Unknown API id ", id}))
+      end
+    elseif type == "tenant" then
+      existing = redis.getTenant(red, id)
+      if existing == nil then
+        request.err(404, utils.concatStrings({"Unknown Tenant id ", id}))
+      end
+    end
+  end
+  return existing
 end
 
 --- Parse the request uri to get the redisKey, tenant, and gatewayPath

--- a/api-gateway-config/tests/run-tests.sh
+++ b/api-gateway-config/tests/run-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Run unit tests
-busted -c --output=TAP --helper=set_paths spec/test.lua
+busted --output=TAP --helper=set_paths spec/test.lua

--- a/api-gateway-config/tests/spec/test.lua
+++ b/api-gateway-config/tests/spec/test.lua
@@ -44,16 +44,16 @@ describe('Testing Request module', function()
     local code = 500
     local msg = 'Internal server error\n'
     request.err(code, msg)
-    assert.are.equal(ngx._body, 'Error: ' .. msg)
-    assert.are.equal(ngx._exit, code)
+    assert.are.equal('Error: ' .. msg .. '\n', ngx._body)
+    assert.are.equal(code, ngx._exit)
   end)
 
   it('should return correct success response', function()
     local code = 200
     local msg ='Success!\n'
     request.success(code, msg)
-    assert.are.equal(ngx._body, msg)
-    assert.are.equal(ngx._exit, code)
+    assert.are.equal(msg .. '\n', ngx._body)
+    assert.are.equal(code, ngx._exit)
   end)
 end)
 

--- a/init.sh
+++ b/init.sh
@@ -53,7 +53,8 @@ api-gateway -p /usr/local/api-gateway/ -c /etc/api-gateway/api-gateway.conf -g "
 
 if [[ -n "${redis_host}" && -n "${redis_port}" ]]; then
     sleep 1  # sleep until api-gateway is set up
-    curl -s http://0.0.0.0:9000/subscribe # subscribe to redis key changes for routes
+    curl -s http://0.0.0.0:9000/v1/sync & # sync with redis
+    curl -s http://0.0.0.0:9000/v1/subscribe # subscribe to redis key changes for routes
 else
     echo "REDIS_HOST and/or REDIS_PORT not defined"
 fi


### PR DESCRIPTION
@mhamann @lostinthestory @DavidMGreen PTAL.
- Added `resourceKeys` redis [set](http://redis.io/commands/SET), which stores all of the `resources:*:*` keys. This set is used to sync with redis, rather than using the `keys("*")` command. Has been tested with 2000+ APIs. Fixes #14 and fixes #24.
- Implemented [coroutines](http://lua-users.org/wiki/CoroutinesTutorial), to run redis sync and subscribe "simultaneously" on startup (actually passing control back and forth between the coroutines). This prevents the sync process from blocking the subscribe process (or vice versa) when the gateway starts up. 