### PR TITLE
Implement health check for gateway sync

### DIFF
--- a/api-gateway-config/conf.d/management_apis.conf
+++ b/api-gateway-config/conf.d/management_apis.conf
@@ -110,4 +110,15 @@ server {
         }
     }
 
+    location /v1/health-check {
+        access_by_lua_block {
+            local mgmt = require("management")
+            local requestMethod = ngx.req.get_method()
+            if requestMethod == "GET" then
+                mgmt.healthCheck()
+            else
+                ngx.say("Invalid verb")
+            end
+        }
+    }
 }

--- a/api-gateway-config/scripts/lua/management.lua
+++ b/api-gateway-config/scripts/lua/management.lua
@@ -492,6 +492,11 @@ function _M.subscribe()
   ngx.exit(200)
 end
 
+--- Get gateway sync status
+function _M.healthCheck()
+  redis.healthCheck()
+end
+
 ---------------------------
 ------ Subscriptions ------
 ---------------------------


### PR DESCRIPTION
Added `/v1/health-check`, which checks the status of gateway sync with redis. Returns 503 if sync is still in progress, 200 if finished. Closes #27. @mhamann @lostinthestory @DavidMGreen PTAL.