### PR TITLE
Tail logs to stdout

### DIFF
--- a/api-gateway-config/conf.d/management_apis.conf
+++ b/api-gateway-config/conf.d/management_apis.conf
@@ -31,7 +31,7 @@ server {
     # Log locations with service name
     lua_socket_log_errors off;
     access_log /var/log/api-gateway/access.log platform;
-    error_log /var/log/api-gateway/mgmt_error.log debug;
+    error_log /var/log/api-gateway/management.log debug;
 
     location /v1/apis {
         access_by_lua_block {

--- a/api-gateway-config/scripts/lua/lib/logger.lua
+++ b/api-gateway-config/scripts/lua/lib/logger.lua
@@ -26,9 +26,15 @@ local utils = require "lib/utils"
 local _M = {}
 
 --- Handle error stream
--- @param s String to write to error stream
+-- @param s String to write to error level of log stream
 function _M.err(s)
   ngx.log(ngx.ERR, s)
+end
+
+--- Handle info logs
+-- @param s String to write to info level of log stream
+function _M.info(s)
+  ngx.log(ngx.INFO, s)
 end
 
 --- Handle debug stream to stdout

--- a/api-gateway-config/scripts/lua/lib/redis.lua
+++ b/api-gateway-config/scripts/lua/lib/redis.lua
@@ -54,7 +54,7 @@ function _M.init(host, port, password, timeout)
     if retryCount == 1 then
       msg = utils.concatStrings({msg:sub(1, -3), "."})
     end
-    logger.debug(msg)
+    logger.info(msg)
     retryCount = retryCount - 1
     os.execute("sleep 1")
     connect, err = red:connect(host, port)
@@ -361,7 +361,7 @@ local syncStatus = false
 --- Sync with redis on startup and create conf files for resources that are already in redis
 -- @param red redis client instance
 function _M.syncWithRedis(red)
-  logger.debug("Sync with redis in progress...")
+  logger.info("Sync with redis in progress...")
   setSyncStatus(true)
   local resourceKeys = getAllResourceKeys(red)
   for k, resourceKey in pairs(resourceKeys) do
@@ -371,7 +371,7 @@ function _M.syncWithRedis(red)
   end
   os.execute("/usr/local/sbin/nginx -s reload")
   setSyncStatus(false)
-  logger.debug("All resources synced.")
+  logger.info("All resources synced.")
 end
 
 function setSyncStatus(status)
@@ -386,7 +386,7 @@ end
 -- @param redisSubClient the redis client that is listening for the redis key changes
 -- @param redisGetClient the redis client that gets the changed resource to update the conf file
 function _M.subscribe(redisSubClient, redisGetClient)
-  logger.debug("Subscribed to redis and listening for key changes...")
+  logger.info("Subscribed to redis and listening for key changes...")
   -- Subscribe to redis using psubscribe
   local ok, err = redisSubClient:config("set", "notify-keyspace-events", "KEA")
   if not ok then
@@ -430,7 +430,7 @@ function _M.subscribe(redisSubClient, redisGetClient)
     local timeDiff = ngx.now() - startTime
     if(redisUpdated == true and timeDiff >= 1) then
       os.execute("/usr/local/sbin/nginx -s reload")
-      logger.debug("Nginx reloaded.")
+      logger.info("Nginx reloaded.")
       redisUpdated = false
       startTime = ngx.now()
     end

--- a/api-gateway-config/scripts/lua/management.lua
+++ b/api-gateway-config/scripts/lua/management.lua
@@ -489,7 +489,7 @@ end
 -- GET /v1/sync
 function _M.sync()
   local red = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 10000)
-  logger.debug(utils.concatStrings({"Connected to redis at ", REDIS_HOST, ":", REDIS_PORT}))
+  logger.info(utils.concatStrings({"Connected to redis at ", REDIS_HOST, ":", REDIS_PORT}))
   redis.syncWithRedis(red)
   ngx.exit(200)
 end

--- a/init.sh
+++ b/init.sh
@@ -53,6 +53,8 @@ api-gateway -p /usr/local/api-gateway/ -c /etc/api-gateway/api-gateway.conf -g "
 
 if [[ -n "${redis_host}" && -n "${redis_port}" ]]; then
     sleep 1  # sleep until api-gateway is set up
+    tail -f /var/log/api-gateway/access.log -f /var/log/api-gateway/error.log \
+         -f /var/log/api-gateway/gateway_error.log -f /var/log/api-gateway/management.log &
     curl -s http://0.0.0.0:9000/v1/sync & # sync with redis
     curl -s http://0.0.0.0:9000/v1/subscribe # subscribe to redis key changes for routes
 else


### PR DESCRIPTION
Closes #40. Tail all logs in `/var/log/api-gateway/` to stdout. Also send previous stdout logs to `management.log` (changed from `mgmt_error.log`). @lostinthestory @mhamann PTAL.