### PR TITLE
Redis routing fix for backend proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ lua_modules
 
 # Concourse
 secrets.yml
+
+# npm
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - ./install-deps.sh
 
 script:
-  - busted --output=TAP --helper=set_paths spec/test.lua
+  - busted --output=TAP --helper=set_paths --pattern=.lua scripts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 apigateway
 =============
+[![Build Status](https://travis-ci.org/openwhisk/apigateway.svg?branch=master)](https://travis-ci.org/openwhisk/apigateway)
+
 A performant API Gateway based on Openresty and NGINX.
 
 Project status
@@ -54,8 +56,6 @@ See [here](doc/routes.md) for the management interface for creating tenants/APIs
  
 ### Testing
 
- Unit tests can be found in the `api-gateway-config/tests/spec` directory.
-
  First install the necessary dependencies:
  ```
   make test-build
@@ -64,5 +64,4 @@ See [here](doc/routes.md) for the management interface for creating tenants/APIs
  ```
   make test-run
  ```
- This will output the results of the tests as well as generate a code coverage report.
 

--- a/api-gateway-config/scripts/lua/routing.lua
+++ b/api-gateway-config/scripts/lua/routing.lua
@@ -42,14 +42,10 @@ function processCall()
   -- Get resource object from redis
   local red = redis.init(REDIS_HOST, REDIS_PORT, REDIS_PASS, 10000)
   local redisKey = findRedisKey(red)
-  local obj
   if redisKey == nil then
     return request.err(404, 'Not found.')
-    --obj = checkForPathParams(red)
-  else
-    obj = redis.getResource(red, redisKey, "resources")
   end
-  obj = cjson.decode(obj)
+  local obj = cjson.decode(redis.getResource(red, redisKey, "resources"))
   local found = false
   for verb, opFields in pairs(obj.operations) do
     if string.upper(verb) == ngx.req.get_method() then
@@ -93,6 +89,10 @@ function findRedisKey(red)
   local keyTable = {}
   for i, key in pairs(resourceKeys) do
     local _, count = string.gsub(key, "/", "")
+    -- handle cases where resource path is "/"
+    if count == 1 and string.sub(key, -1) == "/" then
+      count = count - 1
+    end
     count = tostring(count)
     if keyTable[count] == nil then
       keyTable[count] = {}
@@ -105,16 +105,19 @@ function findRedisKey(red)
   for i = count, 0, -1 do
     local countString = tostring(i)
     if keyTable[countString] ~= nil then
-      for i, key in pairs(keyTable[countString]) do
+      for _, key in pairs(keyTable[countString]) do
         -- Check for exact match or path parameter match
-        if key == redisKey or pathParamMatch(key, redisKey) == true then
-          local res = {string.match(key, "([^:]+):([^:]+):([^:]+)") }
+        if key == redisKey or key == utils.concatStrings({redisKey, "/"}) or pathParamMatch(key, redisKey) == true then
+          local res = {string.match(key, "([^:]+):([^:]+):([^:]+)")}
           ngx.var.gatewayPath = res[3]
           return key
         end
       end
       -- substring redisKey upto last "/"
       local index = redisKey:match("^.*()/")
+      if index == nil then
+        return nil
+      end
       redisKey = string.sub(redisKey, 1, index - 1)
     end
   end
@@ -174,7 +177,9 @@ function getUriPath(backendPath)
   local incomingPath = ((j and ngx.var.uri:sub(j + 1)) or nil)
   -- Check for backendUrl path
   if backendPath == nil or backendPath == '' or backendPath == '/' then
-    return (incomingPath and incomingPath ~= '') and incomingPath or '/'
+    incomingPath = (incomingPath and incomingPath ~= '') and incomingPath or '/'
+    incomingPath = string.sub(incomingPath, 1, 1) == '/' and incomingPath or utils.concatStrings({'/', incomingPath})
+    return incomingPath
   else
     return utils.concatStrings({backendPath, incomingPath})
   end

--- a/api-gateway-config/tests/install-deps.sh
+++ b/api-gateway-config/tests/install-deps.sh
@@ -11,3 +11,4 @@ luarocks install --tree=lua_modules luasocket
 luarocks install --tree=lua_modules sha1
 luarocks install --tree=lua_modules md5
 luarocks install --tree=lua_modules fakeredis
+luarocks install --tree=lua_modules net-url

--- a/api-gateway-config/tests/run-tests.sh
+++ b/api-gateway-config/tests/run-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Run unit tests
-busted --output=TAP --helper=set_paths spec/test.lua
+busted --output=TAP --helper=set_paths --pattern=.lua scripts

--- a/api-gateway-config/tests/scripts/lua/lib/logger.lua
+++ b/api-gateway-config/tests/scripts/lua/lib/logger.lua
@@ -1,0 +1,36 @@
+-- Copyright (c) 2016 IBM. All rights reserved.
+--
+--   Permission is hereby granted, free of charge, to any person obtaining a
+--   copy of this software and associated documentation files (the "Software"),
+--   to deal in the Software without restriction, including without limitation
+--   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+--   and/or sell copies of the Software, and to permit persons to whom the
+--   Software is furnished to do so, subject to the following conditions:
+--
+--   The above copyright notice and this permission notice shall be included in
+--   all copies or substantial portions of the Software.
+--
+--   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+--   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+--   DEALINGS IN THE SOFTWARE.
+
+local fakengx = require 'fakengx'
+local logger = require 'lib/logger'
+
+describe('Testing logger module', function()
+  before_each(function()
+    _G.ngx = fakengx.new()
+  end)
+
+  it('Should handle error stream', function()
+    local msg = 'Error!'
+    logger.err(msg)
+    local expected = 'LOG(4): ' .. msg .. '\n'
+    local generated = ngx._log
+    assert.are.equal(expected, generated)
+  end)
+end)

--- a/api-gateway-config/tests/scripts/lua/lib/request.lua
+++ b/api-gateway-config/tests/scripts/lua/lib/request.lua
@@ -1,0 +1,44 @@
+-- Copyright (c) 2016 IBM. All rights reserved.
+--
+--   Permission is hereby granted, free of charge, to any person obtaining a
+--   copy of this software and associated documentation files (the "Software"),
+--   to deal in the Software without restriction, including without limitation
+--   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+--   and/or sell copies of the Software, and to permit persons to whom the
+--   Software is furnished to do so, subject to the following conditions:
+--
+--   The above copyright notice and this permission notice shall be included in
+--   all copies or substantial portions of the Software.
+--
+--   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+--   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+--   DEALINGS IN THE SOFTWARE.
+
+local fakengx = require 'fakengx'
+local request = require 'lib/request'
+
+describe('Testing Request module', function()
+  before_each(function()
+    _G.ngx = fakengx.new()
+  end)
+
+  it('should return correct error response', function()
+    local code = 500
+    local msg = 'Internal server error\n'
+    request.err(code, msg)
+    assert.are.equal('Error: ' .. msg .. '\n', ngx._body)
+    assert.are.equal(code, ngx._exit)
+  end)
+
+  it('should return correct success response', function()
+    local code = 200
+    local msg ='Success!\n'
+    request.success(code, msg)
+    assert.are.equal(msg .. '\n', ngx._body)
+    assert.are.equal(code, ngx._exit)
+  end)
+end)

--- a/api-gateway-config/tests/scripts/lua/lib/utils.lua
+++ b/api-gateway-config/tests/scripts/lua/lib/utils.lua
@@ -1,0 +1,62 @@
+-- Copyright (c) 2016 IBM. All rights reserved.
+--
+--   Permission is hereby granted, free of charge, to any person obtaining a
+--   copy of this software and associated documentation files (the "Software"),
+--   to deal in the Software without restriction, including without limitation
+--   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+--   and/or sell copies of the Software, and to permit persons to whom the
+--   Software is furnished to do so, subject to the following conditions:
+--
+--   The above copyright notice and this permission notice shall be included in
+--   all copies or substantial portions of the Software.
+--
+--   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+--   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+--   DEALINGS IN THE SOFTWARE.
+
+local fakengx = require 'fakengx'
+local utils = require 'lib/utils'
+
+describe('Testing utils module', function()
+  before_each(function()
+    _G.ngx = fakengx.new()
+  end)
+
+  it('should concatenate strings properly', function()
+    local expected = 'hello' .. 'gateway' .. 'world'
+    local generated = utils.concatStrings({'hello', 'gateway', 'world'})
+    assert.are.equal(expected, generated)
+  end)
+
+  it('should serialize a simple lua table', function()
+    local expected = {
+      test = true
+    }
+    local serialized = utils.serializeTable(expected)
+    loadstring('generated = ' .. serialized)() -- convert serialzed string to lua table
+    assert.are.same(expected, generated)
+  end)
+
+  it('should serialize an empty table', function()
+    local expected = {}
+    local serialized = utils.serializeTable(expected)
+    loadstring('generated = ' .. serialized)() -- convert serialzed string to lua table
+    assert.are.same(expected, generated)
+  end)
+
+  it('should serialize complex nested table', function()
+    local expected = {
+      test1 = {
+        nested = 'value'
+      },
+      test2 = true
+    }
+    local serialized = utils.serializeTable(expected)
+    loadstring('generated = ' .. serialized)() -- convert serialzed string to lua table
+    assert.are.same(expected, generated)
+  end)
+end)

--- a/api-gateway-config/tests/scripts/lua/routing.lua
+++ b/api-gateway-config/tests/scripts/lua/routing.lua
@@ -1,0 +1,122 @@
+-- Copyright (c) 2016 IBM. All rights reserved.
+--
+--   Permission is hereby granted, free of charge, to any person obtaining a
+--   copy of this software and associated documentation files (the "Software"),
+--   to deal in the Software without restriction, including without limitation
+--   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+--   and/or sell copies of the Software, and to permit persons to whom the
+--   Software is furnished to do so, subject to the following conditions:
+--
+--   The above copyright notice and this permission notice shall be included in
+--   all copies or substantial portions of the Software.
+--
+--   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+--   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+--   DEALINGS IN THE SOFTWARE.
+
+local fakengx = require 'fakengx'
+local fakeredis = require 'fakeredis'
+local redis = require 'lib/redis'
+local routing = require 'routing'
+
+describe('Testing routing module', function()
+  before_each(function()
+    _G.ngx = fakengx.new()
+    ngx.var.gatewayPath = ''
+    red = fakeredis.new()
+    operations = {
+      GET = {
+        backendUrl = 'https://httpbin.org',
+        backendMethod = 'GET'
+      }
+    }
+    keys = {'resources:guest:bp1/test/hello', 'resources:guest:bp2/hello', 'resources:guest:bp3/testing/test/hi',
+      'resources:guest:bp4/another/hello', 'resources:guest:nobp', 'resources:guest:noresource/'}
+    local field = 'resources'
+    for _, key in pairs(keys) do
+      red:hset(key, field, redis.generateResourceObj(operations, nil))
+    end
+  end)
+
+  it('should find the correct redis key', function()
+    local expected = 'resources:guest:bp1/test/hello'
+    local tenant = 'guest'
+    local path = 'bp1/test/hello'
+    local actual = routing.findRedisKey(keys, tenant, path)
+    assert.are.same(expected, actual)
+    expected = 'bp1/test/hello'
+    actual = ngx.var.gatewayPath
+    assert.are.same(expected, actual)
+  end)
+
+  it('should return nil if redis key doesn\'t exist', function()
+    local expected = nil
+    local tenant = 'guest'
+    local path = 'bp1/bad/path'
+    local actual = routing.findRedisKey(keys, tenant, path)
+    assert.are.same(expected, actual)
+  end)
+
+  it('should find correct key when basePath is "/"', function()
+    local expected = 'resources:guest:nobp'
+    local tenant = 'guest'
+    local path = 'nobp'
+    local actual = routing.findRedisKey(keys, tenant, path)
+    assert.are.same(expected, actual)
+    expected = 'nobp'
+    actual = ngx.var.gatewayPath
+    assert.are.same(expected, actual)
+  end)
+
+  it('should find correct key when resourcePath is "/"', function()
+    local expected = 'resources:guest:noresource/'
+    local tenant = 'guest'
+    local path = 'noresource/'
+    local actual = routing.findRedisKey(keys, tenant, path)
+    assert.are.same(expected, actual)
+    expected = 'noresource/'
+    actual = ngx.var.gatewayPath
+    assert.are.same(expected, actual)
+  end)
+
+  it('should match the correct path parameters', function()
+    local key = 'resources:guest:bp5/{pathVar}'
+    local redisKey = 'resources:guest:bp5/test'
+    local actual = routing.pathParamMatch(key, redisKey)
+    local expected = true
+    assert.are.same(expected, actual)
+    expected = 'test'
+    actual = ngx.ctx.pathVar
+    assert.are.same(expected, actual)
+  end)
+
+  it('should return false if there isn\'t a path parameter match', function()
+    local key = 'resources:guest:bp6/{pathVar}/hey'
+    local redisKey = 'resources:guest:bp6/test/hi'
+    local actual = routing.pathParamMatch(key, redisKey)
+    local expected = false
+    assert.are.same(expected, actual)
+    expected = nil
+    actual = ngx.ctx.pathVar
+    assert.are.same(expected, actual)
+  end)
+
+  it('should match multiple path parameters', function()
+    local key = 'resources:guest:base/{var1}/hello/{var2}'
+    local redisKey = 'resources:guest:base/test/hello/testing'
+    local actual = routing.pathParamMatch(key, redisKey)
+    local expected = true
+    assert.are.same(expected, actual)
+    expected = 'test'
+    actual = ngx.ctx.var1
+    assert.are.same(expected, actual)
+    expected = 'testing'
+    actual = ngx.ctx.var2
+    assert.are.same(expected, actual)
+  end)
+
+end)

--- a/api-gateway-config/tests/set_paths.lua
+++ b/api-gateway-config/tests/set_paths.lua
@@ -6,6 +6,7 @@ f:close()
 package.path = package.path ..
     ';' .. pwd .. '/lua_modules/share/lua/' .. version .. '/?.lua' ..
     ';' .. pwd .. '/lua_modules/share/lua/' .. version .. '/?/init.lua' ..
+    ';' .. pwd .. '/lua_modules/share/lua/' .. version .. '/net/?.lua' ..
     ';' .. pwd .. '/../scripts/lua/?.lua'
 package.cpath = package.cpath ..
     ';' .. pwd .. '/lua_modules/lib/lua/' .. version .. '/?.so'


### PR DESCRIPTION
Fixes #82 and #80.
1) Due to bad regex handling, the gateway wasn't able to proxy properly to the backend (#82). Based on discussion with @mhamann and @codymwalker, modified `routing.lua` to find the correct redis key based on the number of slashes in basePath + resourcePath
2) Updated how path parameter is handled with the new design
3) Also fixed the cases where the resource path is just a single "/" (#80)

@mhamann @codymwalker @DavidMGreen PTAL
